### PR TITLE
Fix program closing when map changes

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -4,18 +4,15 @@ using System.Diagnostics;
 // Start Process
 var processStartInfo = new ProcessStartInfo
 {
-    FileName = @"BF1942.exe"
+	FileName = @"BF1942.exe"
 };
-
 foreach (var arg in args)
 {
-    processStartInfo.ArgumentList.Add(arg);
+	processStartInfo.ArgumentList.Add(arg);
 }
-
 var process = Process.Start(processStartInfo)!;
-
 var keepAlive = true;
-Console.WriteLine($"[Borderless1942]: [{DateTime.Now:MM/dd/yyyy - hh:mm:ss tt}] [BF1942 Process Has Started]: ({process.Id})");
+Console.WriteLine($"[Borderless1942]: [{DateTime.Now:yyyy-MM-dd - hh:mm:ss tt}] [BF1942 Process Has Started] [{process.Id}]");
 
 // Wait for initial window handle
 var window = await process.WaitForMainWindowAsync();
@@ -25,47 +22,41 @@ window.RemoveBorders();
 while (keepAlive)
 {
 MainLoop:
+	UpdateWindowPosition(window);
+	await Task.Delay(100);
 
-    UpdateWindowPosition(window);
-    await Task.Delay(100);
-
-    if (process.HasExited)
-    {
-        var oldProcessId = process.Id;
-        var retryCount = 0;
-
-        while (retryCount < 2)
-        {
-            var matchingProcesses = Process.GetProcessesByName("BF1942");
-            if (matchingProcesses.Length == 1)
-            {
-                process = matchingProcesses[0];
-
-                Console.WriteLine($"[Borderless1942]: [{DateTime.Now:MM/dd/yyyy - hh:mm:ss tt}] [BF1942 Process Has Changed] [Map Change Detected] ({oldProcessId} -> {process.Id})");
-
-                if (oldProcessId == process.Id)
-                {
-                    Console.WriteLine($"[Borderless1942]: [{DateTime.Now:MM/dd/yyyy - hh:mm:ss tt}] [BF1942 Process Has Been Closed] ({oldProcessId} -> {process.Id})");
-                    keepAlive = false;
-                    break;
-                }
-
-                window = await process.WaitForMainWindowAsync();
-                window.RemoveBorders();
-
-                goto MainLoop;
-            }
-            retryCount++;
-            await Task.Delay(TimeSpan.FromSeconds(1));
-        }
-    }
+	if (process.HasExited)
+	{
+		var oldProcessId = process.Id;
+		var retryCount = 0;
+		while (retryCount < 3)
+		{
+			var matchingProcesses = Process.GetProcessesByName("BF1942");
+			if (matchingProcesses.Length == 1)
+			{
+				process = matchingProcesses[0];
+				if (oldProcessId == process.Id)
+				{
+					Console.WriteLine($"[Borderless1942]: [{DateTime.Now:yyyy-MM-dd - hh:mm:ss tt}] [BF1942 Process Has Exited] [Closing Program] [{oldProcessId} -> {process.Id}]");
+					keepAlive = false;
+					Environment.Exit(0);
+				}
+				Console.WriteLine($"[Borderless1942]: [{DateTime.Now:yyyy-MM-dd - hh:mm:ss tt}] [BF1942 Process Has Changed] [{oldProcessId} -> {process.Id}]");
+				window = await process.WaitForMainWindowAsync();
+				window.RemoveBorders();
+				goto MainLoop;
+			}
+			retryCount++;
+			await Task.Delay(TimeSpan.FromSeconds(1));
+		}
+	}
 }
 
 static void UpdateWindowPosition(Window window)
 {
-    var monitorBounds = window.GetCurrentMonitor().GetBounds();
-    var windowBounds = window.GetBounds();
-    var x = monitorBounds.Width / 2 - windowBounds.Width / 2;
-    var y = monitorBounds.Height / 2 - windowBounds.Height / 2;
-    window.SetPosition(x, y);
+	var monitorBounds = window.GetCurrentMonitor().GetBounds();
+	var windowBounds = window.GetBounds();
+	var x = monitorBounds.Width / 2 - windowBounds.Width / 2;
+	var y = monitorBounds.Height / 2 - windowBounds.Height / 2;
+	window.SetPosition(x, y);
 }

--- a/Program.cs
+++ b/Program.cs
@@ -35,11 +35,11 @@ MainLoop:
 			if (matchingProcesses.Length == 1)
 			{
 				process = matchingProcesses[0];
-				Console.WriteLine($"[Borderless1942]: [{DateTime.Now:yyyy-MM-dd - hh:mm:ss tt}] [BF1942 Process Has Changed] [{oldProcessId} -> {process.Id}]");
-				if (process.HasExited && process.MainWindowHandle == IntPtr.Zero)
+				if (process.HasExited)
 				{
 					break;
 				}
+				Console.WriteLine($"[Borderless1942]: [{DateTime.Now:yyyy-MM-dd - hh:mm:ss tt}] [BF1942 Process Has Changed] [{oldProcessId} -> {process.Id}]");
 				window = await process.WaitForMainWindowAsync();
 				window.RemoveBorders();
 				goto MainLoop;

--- a/Program.cs
+++ b/Program.cs
@@ -4,15 +4,18 @@ using System.Diagnostics;
 // Start Process
 var processStartInfo = new ProcessStartInfo
 {
-	FileName = @"BF1942.exe"
+    FileName = @"BF1942.exe"
 };
+
 foreach (var arg in args)
 {
-	processStartInfo.ArgumentList.Add(arg);
+    processStartInfo.ArgumentList.Add(arg);
 }
+
 var process = Process.Start(processStartInfo)!;
+
 var keepAlive = true;
-Console.WriteLine($"Process has started ({process.Id})");
+Console.WriteLine($"[Borderless1942]: [{DateTime.Now:MM/dd/yyyy - hh:mm:ss tt}] [BF1942 Process Has Started]: ({process.Id})");
 
 // Wait for initial window handle
 var window = await process.WaitForMainWindowAsync();
@@ -22,37 +25,47 @@ window.RemoveBorders();
 while (keepAlive)
 {
 MainLoop:
-	UpdateWindowPosition(window);
-	await Task.Delay(100);
 
-	if (process.HasExited)
-	{
-		var oldProcessId = process.Id;
-		var retryCount = 0;
-		while (retryCount < 2)
-		{
-			var matchingProcesses = Process.GetProcessesByName("BF1942");
-			if (matchingProcesses.Length == 1)
-			{
-				process = matchingProcesses[0];
-				Console.WriteLine($"Process has changed ({oldProcessId} -> {process.Id})");
-				window = await process.WaitForMainWindowAsync();
-				window.RemoveBorders();
-				goto MainLoop;
-			}
-			retryCount++;
-			await Task.Delay(TimeSpan.FromSeconds(1));
-		}
-		keepAlive = false;
-		Console.WriteLine($"Process has exited ({oldProcessId})");
-	}
+    UpdateWindowPosition(window);
+    await Task.Delay(100);
+
+    if (process.HasExited)
+    {
+        var oldProcessId = process.Id;
+        var retryCount = 0;
+
+        while (retryCount < 2)
+        {
+            var matchingProcesses = Process.GetProcessesByName("BF1942");
+            if (matchingProcesses.Length == 1)
+            {
+                process = matchingProcesses[0];
+
+                Console.WriteLine($"[Borderless1942]: [{DateTime.Now:MM/dd/yyyy - hh:mm:ss tt}] [BF1942 Process Has Changed] [Map Change Detected] ({oldProcessId} -> {process.Id})");
+
+                if (oldProcessId == process.Id)
+                {
+                    Console.WriteLine($"[Borderless1942]: [{DateTime.Now:MM/dd/yyyy - hh:mm:ss tt}] [BF1942 Process Has Been Closed] ({oldProcessId} -> {process.Id})");
+                    keepAlive = false;
+                    break;
+                }
+
+                window = await process.WaitForMainWindowAsync();
+                window.RemoveBorders();
+
+                goto MainLoop;
+            }
+            retryCount++;
+            await Task.Delay(TimeSpan.FromSeconds(1));
+        }
+    }
 }
 
 static void UpdateWindowPosition(Window window)
 {
-	var monitorBounds = window.GetCurrentMonitor().GetBounds();
-	var windowBounds = window.GetBounds();
-	var x = monitorBounds.Width / 2 - windowBounds.Width / 2;
-	var y = monitorBounds.Height / 2 - windowBounds.Height / 2;
-	window.SetPosition(x, y);
+    var monitorBounds = window.GetCurrentMonitor().GetBounds();
+    var windowBounds = window.GetBounds();
+    var x = monitorBounds.Width / 2 - windowBounds.Width / 2;
+    var y = monitorBounds.Height / 2 - windowBounds.Height / 2;
+    window.SetPosition(x, y);
 }

--- a/Program.cs
+++ b/Program.cs
@@ -35,13 +35,11 @@ MainLoop:
 			if (matchingProcesses.Length == 1)
 			{
 				process = matchingProcesses[0];
-				if (oldProcessId == process.Id)
-				{
-					Console.WriteLine($"[Borderless1942]: [{DateTime.Now:yyyy-MM-dd - hh:mm:ss tt}] [BF1942 Process Has Exited] [Closing Program] [{oldProcessId} -> {process.Id}]");
-					keepAlive = false;
-					Environment.Exit(0);
-				}
 				Console.WriteLine($"[Borderless1942]: [{DateTime.Now:yyyy-MM-dd - hh:mm:ss tt}] [BF1942 Process Has Changed] [{oldProcessId} -> {process.Id}]");
+				if (process.HasExited && process.MainWindowHandle == IntPtr.Zero)
+				{
+					break;
+				}
 				window = await process.WaitForMainWindowAsync();
 				window.RemoveBorders();
 				goto MainLoop;
@@ -49,7 +47,9 @@ MainLoop:
 			retryCount++;
 			await Task.Delay(TimeSpan.FromSeconds(1));
 		}
-	}
+		keepAlive = false;
+		Console.WriteLine($"[Borderless1942]: [{DateTime.Now:yyyy-MM-dd - hh:mm:ss tt}] [BF1942 Process Has Exited]");
+    }
 }
 
 static void UpdateWindowPosition(Window window)


### PR DESCRIPTION
I would like to start by thanking James Turner for creating Borderless1942 for my favorite game Battlefield 1942.

This is my first GitHub pull request, so please let me know if I did something incorrectly. :)

Recently while playing Battlefield 1942 using Borderless1942, I discovered the program would close during a multiplayer map change.  Since I enjoy programming, I decided to dig into the code and figure out what was happening.  Below is the small modification that I made to prevent the Borderless1942 program from closing when changing maps during multiplayer.

I tested the changes locally in COOP mode using the master.bf1942.org master server patch from the link below.
https://www.moddb.com/games/battlefield-1942/downloads/bf1942-masterbf1942org-patch