### PR TITLE
Auto patch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,12 +28,12 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    - name: Setup dotnet 6.0
+    - name: Setup dotnet 9.0
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 9.0.x
     - name: Build
-      run: dotnet publish -c Release --output ${{env.BUILD_ARTIFACT_PATH}} -r win-x64 -p:PublishSingleFile=true --self-contained true
+      run: dotnet publish -c Release --output ${{env.BUILD_ARTIFACT_PATH}} -r win-x64
     - name: Publish artifacts
       uses: actions/upload-artifact@v2
       with:

--- a/Borderless1942.csproj
+++ b/Borderless1942.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -8,6 +8,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	<RuntimeIdentifier>win-x64</RuntimeIdentifier>
 	<PublishAot>true</PublishAot>
+	<ApplicationManifest>Properties\app.manifest</ApplicationManifest>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Borderless1942.csproj
+++ b/Borderless1942.csproj
@@ -2,14 +2,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-	<PublishTrimmed>true</PublishTrimmed>
-	<DebugType>embedded</DebugType>
-	<IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
-	<RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
+	<RuntimeIdentifier>win-x64</RuntimeIdentifier>
+	<PublishAot>true</PublishAot>
   </PropertyGroup>
 
   <ItemGroup>

--- a/NativeMethods.txt
+++ b/NativeMethods.txt
@@ -1,6 +1,8 @@
-﻿MonitorFromWindow
+﻿MonitorFromPoint
+MonitorFromWindow
 GetMonitorInfo
 SetWindowPos
+SetProcessDPIAwareness
 SendMessage
 GetWindowInfo
 SetWindowLong

--- a/Program.cs
+++ b/Program.cs
@@ -8,6 +8,8 @@ var width = defaultWidth;
 var height = defaultHeight;
 var skipConfigEdits = false;
 
+List<string> additionalArgs = new();
+
 for (int i = 0; i < args.Length; i++)
 {
 	if (args[i].Equals("-width", StringComparison.OrdinalIgnoreCase) && i + 1 < args.Length)
@@ -28,6 +30,8 @@ for (int i = 0; i < args.Length; i++)
 	{
 		skipConfigEdits = true;
 	}
+	else
+		additionalArgs.Add(args[i]);
 }
 
 if (!skipConfigEdits)
@@ -73,8 +77,11 @@ if (!skipConfigEdits)
 // Start Process
 var processStartInfo = new ProcessStartInfo
 {
-	FileName = @"BF1942.exe"
+	FileName = @"BF1942.exe",
 };
+
+foreach (var arg in additionalArgs)
+	processStartInfo.ArgumentList.Add(arg);
 
 var process = Process.Start(processStartInfo)!;
 var keepAlive = true;

--- a/Program.cs
+++ b/Program.cs
@@ -1,15 +1,81 @@
 ﻿using Borderless1942;
 using System.Diagnostics;
 
+var monitorBounds = Win32Extensions.GetPrimaryMonitor().GetBounds();
+var defaultWidth = monitorBounds.Width;
+var defaultHeight = monitorBounds.Height;
+var width = defaultWidth;
+var height = defaultHeight;
+var skipConfigEdits = false;
+
+for (int i = 0; i < args.Length; i++)
+{
+	if (args[i].Equals("-width", StringComparison.OrdinalIgnoreCase) && i + 1 < args.Length)
+	{
+		if (int.TryParse(args[i + 1], out int parsedWidth))
+		{
+			width = parsedWidth;
+		}
+	}
+	else if (args[i].Equals("-height", StringComparison.OrdinalIgnoreCase) && i + 1 < args.Length)
+	{
+		if (int.TryParse(args[i + 1], out int parsedHeight))
+		{
+			height = parsedHeight;
+		}
+	}
+	else if (args[i].Equals("-noedit", StringComparison.OrdinalIgnoreCase))
+	{
+		skipConfigEdits = true;
+	}
+}
+
+if (!skipConfigEdits)
+{
+	// Update Video.con files if they exist
+	var modsPath = Path.Combine(Environment.CurrentDirectory, "Mods", "bf1942", "Settings");
+	if (Directory.Exists(modsPath))
+	{
+		// Update resolution in profile Video.con files
+		var videoConFiles = Directory.GetFiles(Path.Combine(modsPath, "Profiles"), "Video.con", SearchOption.AllDirectories);
+		foreach (var videoConFile in videoConFiles)
+		{
+			var lines = File.ReadAllLines(videoConFile);
+			for (int i = 0; i < lines.Length; i++)
+			{
+				if (lines[i].StartsWith("game.setGameDisplayMode"))
+				{
+					lines[i] = $"game.setGameDisplayMode {width} {height} 32 60";
+				}
+			}
+			File.WriteAllLines(videoConFile, lines);
+			Console.WriteLine($"[Borderless1942]: [{DateTime.Now:yyyy-MM-dd - hh:mm:ss tt}] [Updated resolution in {videoConFile} to {width}x{height}]");
+		}
+
+		// Update fullscreen setting in VideoDefault.con
+		var videoDefaultPath = Path.Combine(modsPath, "VideoDefault.con");
+		if (File.Exists(videoDefaultPath))
+		{
+			var lines = File.ReadAllLines(videoDefaultPath);
+			for (int i = 0; i < lines.Length; i++)
+			{
+				if (lines[i].StartsWith("renderer.setFullScreen"))
+				{
+					lines[i] = "renderer.setFullScreen 0";
+				}
+			}
+			File.WriteAllLines(videoDefaultPath, lines);
+			Console.WriteLine($"[Borderless1942]: [{DateTime.Now:yyyy-MM-dd - hh:mm:ss tt}] [Updated fullscreen setting in VideoDefault.con]");
+		}
+	}
+}
+
 // Start Process
 var processStartInfo = new ProcessStartInfo
 {
 	FileName = @"BF1942.exe"
 };
-foreach (var arg in args)
-{
-	processStartInfo.ArgumentList.Add(arg);
-}
+
 var process = Process.Start(processStartInfo)!;
 var keepAlive = true;
 Console.WriteLine($"[Borderless1942]: [{DateTime.Now:yyyy-MM-dd - hh:mm:ss tt}] [BF1942 Process Has Started] [{process.Id}]");
@@ -49,7 +115,7 @@ MainLoop:
 		}
 		keepAlive = false;
 		Console.WriteLine($"[Borderless1942]: [{DateTime.Now:yyyy-MM-dd - hh:mm:ss tt}] [BF1942 Process Has Exited]");
-    }
+	}
 }
 
 static void UpdateWindowPosition(Window window)

--- a/Properties/app.manifest
+++ b/Properties/app.manifest
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/Win32Extensions.cs
+++ b/Win32Extensions.cs
@@ -10,7 +10,18 @@ namespace Borderless1942;
 
 public static class Win32Extensions
 {
-	public static async ValueTask<Window> WaitForMainWindowAsync(this Process process)
+    public static Monitor GetPrimaryMonitor()
+    {
+        nint handle = PInvoke.MonitorFromPoint(new POINT
+        {
+            x = 0,
+            y = 0
+        }, 0);
+
+        return new(handle);
+    }
+
+    public static async ValueTask<Window> WaitForMainWindowAsync(this Process process)
 	{
 		while (process.MainWindowHandle == IntPtr.Zero)
 		{


### PR DESCRIPTION
- Automatically patches `Video.con` and `VideoDefault.con` for windowed with resolution matching primary monitor
- Adds arguments to support custom resolutions using `-width <int>` and `-height <int>`
- Adds argument to avoid changing `.con` files with `-noedit`
- Made application DPI aware so window size is correct even with display scaling
- Updated to .NET 9
- Publish AOT for smaller executable with no need for extraction